### PR TITLE
Add unique index on short_url column

### DIFF
--- a/database/migrations/2018_10_06_173659_alter_urls_make_short_url_unique.php
+++ b/database/migrations/2018_10_06_173659_alter_urls_make_short_url_unique.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class MakeShortUrlUnique extends Migration
+class AlterUrlsMakeShortUrlUnique extends Migration
 {
     /**
      * Run the migrations.

--- a/database/migrations/2018_10_06_173659_make_short_url_unique.php
+++ b/database/migrations/2018_10_06_173659_make_short_url_unique.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class MakeShortUrlUnique extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('urls', function (Blueprint $table) {
+            $table->unique('short_url', 'unique_short_url');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('urls', function (Blueprint $table) {
+            $table->dropUnique('unique_short_url');
+        });
+    }
+}


### PR DESCRIPTION
Adds unique key for `short_url` on the urls table.

If the app is later setup for base conversion as discussed in #9, it's probably still worth adding unique at the db level in case of direct/external database changes.